### PR TITLE
Vagrant support to simplify deployment and installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This tool is only for testing and academic purposes Do not use it for illegal pu
 ## Installation
 Download Zydra by cloning the Git repository:
   <br />```$ git clone https://github.com/hamedA2/Zydra.git```
+  
+You can also use [vagrant](https://www.vagrantup.com/) to automatically install and run Zydra (more information at the bottom of the page).
 ## Usage
 To get a list of all options and learn how to use this app, enter the following command:<br />
   <br />```$ python3 Zydra.py -h```
@@ -46,6 +48,31 @@ To get a list of all options and learn how to use this app, enter the following 
 <br /><br />```$ python3 Zydra.py –f shadow –b digits,symbols –m 4 –x 4```<br /><br />
 ![alt text](https://github.com/hamedA2/images/blob/master/shadow_modified.png)
 
+## Vagrant
+To run Zydra using vagrant use the following command (you have to be in the same folder as the repository):
+
+`vagrant up`
+
+and once it finishes inialisation, you can run:
+
+`vagrant ssh`
+
+to connect to the virtual machine.
+
+To exit the virtual machine just type `exit` in the shell.
+
+To destroy the virtual machine run `vagrant destroy`.
+
+More information regarding vagrant usage can be found [here](https://www.vagrantup.com/docs/cli/)
+
+**Note:**
+By default the `Vagrantfile` uses the following settings:
+```
+    vb.cpus = 4
+    vb.memory = 4096
+```
+Edit the `Vagrantfile` and change those values to improve the performance.
+
 ## Author
 
 * **Hamed Hosseini** 
@@ -54,3 +81,4 @@ A special thank to, [Hamed Izadi](https://github.com/hamedeasy)
 ## License
 This project is licensed under the MIT License - see the [LICENSE.md](https://github.com/hamedA2/Zydra/blob/master/LICENSE) file for details
  		
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,15 @@
+Vagrant.configure(2) do |config|
+    config.vm.box = "hashicorp/bionic64"
+    config.vm.provider "virtualbox" do |vb|
+      vb.cpus = 4
+      vb.memory = 4096
+    end
+    config.vm.hostname = "test"
+    config.vm.network "forwarded_port", guest: 80, host: 8081
+    config.vm.network "forwarded_port", guest: 443, host: 8082
+    config.vm.synced_folder ".", "/vagrant"
+    config.ssh.extra_args = ["-t", "cd /vagrant; bash --login"]
+    config.ssh.forward_agent = true  
+    config.vm.provision "shell", path: "script.sh"
+end
+  

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,9 +4,7 @@ Vagrant.configure(2) do |config|
       vb.cpus = 4
       vb.memory = 4096
     end
-    config.vm.hostname = "test"
-    config.vm.network "forwarded_port", guest: 80, host: 8081
-    config.vm.network "forwarded_port", guest: 443, host: 8082
+    config.vm.hostname = "Zydra"
     config.vm.synced_folder ".", "/vagrant"
     config.ssh.extra_args = ["-t", "cd /vagrant; bash --login"]
     config.ssh.forward_agent = true  

--- a/script.sh
+++ b/script.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+export DEBIAN_FRONTEND=noninteractive
+
+sudo apt-get update -y
+# sudo apt-get upgrade -y
+# Workaround for the grub-config-prompt issue :
+DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+# As taken from here :
+# https://askubuntu.com/questions/146921/how-do-i-apt-get-y-dist-upgrade-without-a-grub-config-prompt
+
+sudo apt-get install qpdf -y
+sudo apt-get install unrar -y
+sudo apt-get install python3.7 -y 
+sudo apt-get install python3-pip -y
+pip3 --version
+
+pip3 install zipfile
+pip3 install rarfile
+pip3 install pyfiglet
+pip3 install py-term
+pip3 install termcolor
+
+cd /vagrant/


### PR DESCRIPTION
Hello,

I found your tool interesting, so to simplify deployment + installation i ported it to Vagrant.
In case you don't know Vagrant, it allows to use your tool on macOS, Linux, Windows.
And i think it may be usefull for others too.
More information on vagrant can be found [here](https://en.wikipedia.org/wiki/Vagrant_%28software%29)

The `script.sh` tries to automate installation of the different prerequisites + Python3, so that the tool can be used out of the box.

I also briefly updated the `readme.md` to give a short explanation on how to use vagrant.

If you'd like to, you can also add me as a contributor :) 