### PR TITLE
SyntaxWarning, python 3.7 deprecation

### DIFF
--- a/Zydra.py
+++ b/Zydra.py
@@ -298,7 +298,7 @@ class Zydra():
             if self.stop is True:
                 exit(0)
             elif self.count == len(passwords_list):# self_cont kam mishe
-                if self.file_type is "rar":
+                if self.file_type == "rar":
                     self.search_rar_pass(passwords_list, file, max_words)
                 if self.stop is False:
                     print("\n\t" + self.red("[-] Password not found") + "\n")

--- a/script.sh
+++ b/script.sh
@@ -10,7 +10,7 @@ DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -
 
 sudo apt-get install qpdf -y
 sudo apt-get install unrar -y
-sudo apt-get install python3.7 -y 
+sudo apt-get install python3 -y 
 sudo apt-get install python3-pip -y
 pip3 --version
 


### PR DESCRIPTION
Python 3.8+ warning Fixed, "is" is replaced with "=="

Instead of python 3.7, it is replaced by python3 which installs the latest python3 candidate.