### PR TITLE
SyntaxWarning: "is" with a literal. Did you mean "=="?

### DIFF
--- a/Zydra.py
+++ b/Zydra.py
@@ -298,7 +298,7 @@ class Zydra():
             if self.stop is True:
                 exit(0)
             elif self.count == len(passwords_list):# self_cont kam mishe
-                if self.file_type is "rar":
+                if self.file_type == "rar":
                     self.search_rar_pass(passwords_list, file, max_words)
                 if self.stop is False:
                     print("\n\t" + self.red("[-] Password not found") + "\n")


### PR DESCRIPTION
Python 3.8+ warning Fixed, "is" is replaced with "=="